### PR TITLE
Update GitHub Actions bot user name and email

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -18,8 +18,8 @@ rm split.py
 
 echo "Commiting and pushing"
 
-git config --global user.email "action@github.com"
-git config --global user.name "GitHub Actions Bot"
+git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git config --global user.name "github-actions[bot]"
 
 git add ${INPUT_ROOT_FOLDER}${INPUT_OUTPUT_FOLDER} ${INPUT_OUTPUT_MD} > /dev/null
 git diff-index --quiet HEAD || git commit -m "Compile MD" --quiet


### PR DESCRIPTION
The git author/committer is currently set to `GitHub Actions Bot <action@github.com>`,
while `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>` seems to be the preferred choice.

This small PR changes the git user to the later.

Some references:
- https://github.com/orgs/community/discussions/26560
- https://github.com/actions/checkout/issues/13